### PR TITLE
fix Session::isEmpty method always returning true

### DIFF
--- a/src/WebTerminal/Session.php
+++ b/src/WebTerminal/Session.php
@@ -21,7 +21,7 @@ class Session
      */
     public function isEmpty(): bool
     {
-        return empty($data);
+        return empty($this->data);
     }
 
     /**


### PR DESCRIPTION
Fix Session::isEmpty() method returning true regardless of session contents.