### PR TITLE
Remove decoding predefined json

### DIFF
--- a/src/WebTerminal/Logger.php
+++ b/src/WebTerminal/Logger.php
@@ -24,9 +24,10 @@ class Logger
      */
     private function loadData(): void
     {
-        $filePath = $this->filePath;
-        if (($json = file_get_contents($filePath)) === false) {
-            $json = '{}';
+        if (($json = file_get_contents($this->filePath)) === false) {
+            $this->data = [];
+
+            return;
         }
 
         $this->data = json_decode($json, true) ?? [];


### PR DESCRIPTION
Remove decoding predefined json - result is known before decoding. This is redundant operation that will always result in empty array.